### PR TITLE
キャッシュ設定の追加

### DIFF
--- a/etc/mysql/my.cnf
+++ b/etc/mysql/my.cnf
@@ -19,3 +19,9 @@
 
 !includedir /etc/mysql/conf.d/
 !includedir /etc/mysql/mysql.conf.d/
+[mysqld]
+log_slow_admin_statements=1
+slow_query_log=1
+slow_query_log_file=/var/log/mysql/mysql-slow.log
+long_query_time=0
+disable_log_bin=0

--- a/etc/nginx/isucon-php.conf
+++ b/etc/nginx/isucon-php.conf
@@ -7,6 +7,11 @@ server {
     location / {
         try_files $uri /index.php$is_args$args;
     }
+    location /image/ {
+	root /app/;
+	expires 30d;
+	try_files $uri /index.php$is_args$args;
+    }
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     location ~ \.php {


### PR DESCRIPTION
CPUを生かしきれていなかったのは、画像ファイルの配布によってネットワークの帯域がボトルネックになっていたことが原因らしい。
そこで、キャッシュで対応できる画像は配布しないように設定する。