### PR TITLE
SELECT * FROM users WHERE id = ? クエリを減らす

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -93,7 +93,7 @@ $container->set('helper', function ($c) {
             foreach($sql as $s) {
                 $db->query($s);
             }
-	        $db->query('update comments set comments.account_name = users.account_name from comments inner join users on comments.user_id = users.id');
+            $db->query('update comments set comments.account_name = users.account_name from comments inner join users on comments.user_id = users.id');
             $db->query('update posts set posts.del_flg = users.del_flg from posts inner join users on posts.user_id = users.id');
         }
         public function fetch_first($query, ...$params) {

--- a/php/index.php
+++ b/php/index.php
@@ -94,6 +94,7 @@ $container->set('helper', function ($c) {
                 $db->query($s);
             }
 	        $db->query('update comments set comments.account_name = users.account_name from comments inner join users on comments.user_id = users.id');
+            $db->query('update posts set posts.del_flg = users.del_flg from posts inner join users on posts.user_id = users.id');
         }
         public function fetch_first($query, ...$params) {
             $db = $this->db();
@@ -143,7 +144,6 @@ $container->set('helper', function ($c) {
                 $comments = $ps->fetchAll(PDO::FETCH_ASSOC);
                 foreach ($comments as &$comment) {
                     $comment['user']['account_name'] = $comment['account_name'];
-                    //$comment['user'] = $this->fetch_first('SELECT account_name FROM `users` WHERE `id` = ?', $comment['user_id']);
                 }
                 unset($comment);
                 $post['comments'] = array_reverse($comments);


### PR DESCRIPTION
```
# Rank Query ID                            Response time Calls R/Call V/M 
# ==== =================================== ============= ===== ====== ====
#    1 0x624863D30DAC59FA16849282195BE09F  30.3141 34.0% 89443 0.0003  0.00 SELECT comments
#    2 0x396201721CD58410E070DA9421CA8C8D  28.1977 31.6% 92924 0.0003  0.00 SELECT users
#    3 0x19759A5557089FD5B718D440CBBB5C55   7.3981  8.3%  3177 0.0023  0.00 SELECT posts
#    4 0xAA65B65D6FEC3514934B143907BBE8A0   6.7436  7.6%   298 0.0226  0.00 SELECT posts
#    5 0x009A61E5EFBD5A5E4097914B4DBD1C07   6.6230  7.4%    96 0.0690  0.04 INSERT posts
```
実行時間が2番目のクエリは以下のようなもので、users.del_flgを呼ぶためだけに呼び出されている。
```
SELECT * FROM `users` WHERE `id` = '630'
```